### PR TITLE
format fields as a separate map without core changes

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dev-dependencies]
 
 # tracing crates
-tracing = { version = "0.1", path = "../tracing" }
-tracing-core = { version = "0.1", path = "../tracing-core" }
+tracing = "0.1"
+tracing-core = "0.1"
 tracing-tower = { version = "0.1.0", path = "../tracing-tower" }
 tracing-subscriber = { version = "0.1", path = "../tracing-subscriber" }
 tracing-futures = { version = "0.1.0", path = "../tracing-futures" }

--- a/nightly-examples/Cargo.toml
+++ b/nightly-examples/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
-tracing = { version = "0.1", path = "../tracing" }
+tracing = "0.1"
 tracing-subscriber = { version = "0.1", path = "../tracing-subscriber", features = ["json"] }
 tracing-futures = { path = "../tracing-futures", default-features = false, features = ["std-future"] }
 tokio = { git = "https://github.com/tokio-rs/tokio.git" }

--- a/tracing-attributes/Cargo.toml
+++ b/tracing-attributes/Cargo.toml
@@ -44,7 +44,7 @@ quote = "1"
 
 
 [dev-dependencies]
-tracing = { version = "0.1", path = "../tracing" }
+tracing = "0.1"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-attributes/test_async_await/Cargo.toml
+++ b/tracing-attributes/test_async_await/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 
 [dev-dependencies]
 tokio-test = { git = "https://github.com/tokio-rs/tokio.git" }
-tracing = { version = "0.1", path = "../../tracing" }
-tracing-core = { version = "0.1", path = "../../tracing-core" }
+tracing = "0.1"
+tracing-core = "0.1"
 tracing-futures = { path = "../../tracing-futures", features = ["std-future"] }
 tracing-attributes = { path = ".." }
 test_std_future = { path = "../../tracing-futures/test_std_future" }

--- a/tracing-core/src/event.rs
+++ b/tracing-core/src/event.rs
@@ -94,11 +94,6 @@ impl<'a> Event<'a> {
         self.fields.field_set().iter()
     }
 
-    /// Returns the field values on this `Event`.
-    pub fn values(&self) -> &field::ValueSet {
-        &self.fields
-    }
-
     /// Returns [metadata] describing this `Event`.
     ///
     /// [metadata]: ../metadata/struct.Metadata.html

--- a/tracing-core/src/field.rs
+++ b/tracing-core/src/field.rs
@@ -599,7 +599,7 @@ impl<'a> ValueSet<'a> {
     /// Visits all the fields in this `ValueSet` with the provided [visitor].
     ///
     /// [visitor]: ../trait.Visit.html
-    pub fn record(&self, visitor: &mut dyn Visit) {
+    pub(crate) fn record(&self, visitor: &mut dyn Visit) {
         let my_callsite = self.callsite();
         for (field, value) in self.values {
             if field.callsite() != my_callsite {
@@ -609,11 +609,6 @@ impl<'a> ValueSet<'a> {
                 value.record(field, visitor);
             }
         }
-    }
-
-    /// The number of elements in the `ValueSet`.
-    pub fn len(&self) -> usize {
-        self.fields.len()
     }
 
     /// Returns `true` if this `ValueSet` contains a value for the given `Field`.

--- a/tracing-futures/Cargo.toml
+++ b/tracing-futures/Cargo.toml
@@ -29,7 +29,7 @@ tokio-alpha = ["std-future", "tokio_02"]
 futures = { version = "0.1", optional = true }
 futures-core-preview = { version = "0.3.0-alpha.19", optional = true }
 pin-project = { version = "0.4", optional = true }
-tracing = { version = "0.1", path = "../tracing" }
+tracing = "0.1"
 tokio-executor = { version = "0.1", optional = true }
 tokio = { version = "0.1", optional = true }
 tokio_02 = { package = "tokio", version = "0.2.0-alpha.6", optional = true }

--- a/tracing-futures/test_std_future/Cargo.toml
+++ b/tracing-futures/test_std_future/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2018"
 
 [dependencies]
 tokio-test = { git = "https://github.com/tokio-rs/tokio.git" }
-tracing = { version = "0.1", path = "../../tracing" }
-tracing-core = { version = "0.1.2", path = "../../tracing-core" }
+tracing = "0.1"
+tracing-core = "0.1.2"
 tracing-futures = { path = "..", features = ["std-future"] }

--- a/tracing-log/Cargo.toml
+++ b/tracing-log/Cargo.toml
@@ -23,13 +23,13 @@ log-tracer = []
 trace-logger = []
 
 [dependencies]
-tracing-core = { path = "../tracing-core" }
+tracing-core = "0.1.2"
 log = { version = "0.4", features = ["std"] }
 lazy_static = "1.3.0"
 env_logger = { version = "0.6", optional = true }
 
 [dev-dependencies]
-tracing = { path = "../tracing" }
+tracing = "0.1"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-macros/Cargo.toml
+++ b/tracing-macros/Cargo.toml
@@ -18,10 +18,10 @@ keywords = ["logging", "tracing"]
 license = "MIT"
 
 [dependencies]
-tracing = { version = "0.1", path = "../tracing" }
+tracing = "0.1"
 
 [dev-dependencies]
-tracing-log = { version = "0.1", path = "../tracing-log" }
+tracing-log = "0.1"
 env_logger = "0.5"
 
 [badges]

--- a/tracing-serde/Cargo.toml
+++ b/tracing-serde/Cargo.toml
@@ -20,7 +20,7 @@ keywords = ["logging", "tracing", "serialization"]
 
 [dependencies]
 serde = "1"
-tracing-core = { path = "../tracing-core" }
+tracing-core = "0.1.2"
 
 [badges]
 azure-devops = { project = "tracing/tracing", pipeline = "tokio-rs.tracing", build = "1" }

--- a/tracing-serde/src/fields.rs
+++ b/tracing-serde/src/fields.rs
@@ -1,0 +1,55 @@
+//! Support for serializing fields as `serde` structs or maps.
+use super::*;
+
+#[derive(Debug)]
+pub struct SerializeFieldMap<'a, T:>(&'a T);
+
+pub trait AsMap: Sized + sealed::Sealed {
+    fn field_map(&self) -> SerializeFieldMap<Self> {
+        SerializeFieldMap(self)
+    }
+}
+
+impl<'a> AsMap for Event<'a> {}
+impl<'a> AsMap for Attributes<'a> {}
+impl<'a> AsMap for Record<'a> {}
+
+// === impl SerializeFieldMap ===
+
+impl<'a> Serialize for SerializeFieldMap<'a, Event<'_>> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let len = self.0.metadata().fields().len();
+        let serializer = serializer.serialize_map(Some(len))?;
+        let mut visitor = SerdeMapVisitor::new(serializer);
+        self.0.record(&mut visitor);
+        visitor.finish()
+    }
+}
+
+impl<'a> Serialize for SerializeFieldMap<'a, Attributes<'_>> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let len = self.0.metadata().fields().len();
+        let serializer = serializer.serialize_map(Some(len))?;
+        let mut visitor = SerdeMapVisitor::new(serializer);
+        self.0.record(&mut visitor);
+        visitor.finish()
+    }
+}
+
+impl<'a> Serialize for SerializeFieldMap<'a, Record<'_>> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let serializer = serializer.serialize_map(None)?;
+        let mut visitor = SerdeMapVisitor::new(serializer);
+        self.0.record(&mut visitor);
+        visitor.finish()
+    }
+}

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -15,6 +15,8 @@ use tracing_core::{
     span::{Attributes, Id, Record},
 };
 
+pub mod fields;
+
 /// A bridge between `fmt::Write` and `io::Write`.
 ///
 /// This is needed because tracing-subscriber's FormatEvent expects a fmt::Write

--- a/tracing-serde/src/lib.rs
+++ b/tracing-serde/src/lib.rs
@@ -10,7 +10,7 @@ use serde::{
 
 use tracing_core::{
     event::Event,
-    field::{Field, FieldSet, ValueSet, Visit},
+    field::{Field, FieldSet, Visit},
     metadata::{Level, Metadata},
     span::{Attributes, Id, Record},
 };
@@ -157,22 +157,6 @@ impl<'a> Serialize for SerializeEvent<'a> {
             serializer,
             state: Ok(()),
         };
-        self.0.record(&mut visitor);
-        visitor.finish()
-    }
-}
-
-/// Implements `serde::Serialize` to write `ValueSet` data to a serializer.
-#[derive(Debug)]
-pub struct SerializeValueSet<'a>(&'a ValueSet<'a>);
-
-impl<'a> Serialize for SerializeValueSet<'a> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let serializer = serializer.serialize_map(Some(self.0.len()))?;
-        let mut visitor = SerdeMapVisitor::new(serializer);
         self.0.record(&mut visitor);
         visitor.finish()
     }
@@ -357,14 +341,6 @@ impl<'a> AsSerde<'a> for tracing_core::Event<'a> {
     }
 }
 
-impl<'a> AsSerde<'a> for ValueSet<'a> {
-    type Serializable = SerializeValueSet<'a>;
-
-    fn as_serde(&'a self) -> Self::Serializable {
-        SerializeValueSet(self)
-    }
-}
-
 impl<'a> AsSerde<'a> for tracing_core::span::Attributes<'a> {
     type Serializable = SerializeAttributes<'a>;
 
@@ -398,8 +374,6 @@ impl<'a> AsSerde<'a> for Level {
 }
 
 impl<'a> self::sealed::Sealed for Event<'a> {}
-
-impl<'a> self::sealed::Sealed for ValueSet<'a> {}
 
 impl<'a> self::sealed::Sealed for Attributes<'a> {}
 

--- a/tracing-subscriber/Cargo.toml
+++ b/tracing-subscriber/Cargo.toml
@@ -30,7 +30,7 @@ json = ["tracing-serde", "serde", "serde_json"]
 filter = ["env-filter"]
 
 [dependencies]
-tracing-core = { path = "../tracing-core" }
+tracing-core = "0.1.2"
 
 # only required by the filter feature
 matchers = { optional = true, version = "0.0.1" }
@@ -39,7 +39,7 @@ smallvec = { optional = true, version = "0.6.10"}
 lazy_static = { optional = true, version = "1" }
 
 # fmt
-tracing-log = { path = "../tracing-log", optional = true, default-features = false }
+tracing-log = { version = "0.1", optional = true, default-features = false }
 ansi_term = { version = "0.11", optional = true }
 owning_ref = { version = "0.4.0", optional = true }
 chrono = { version = "0.4", optional = true }
@@ -53,9 +53,9 @@ tracing-serde = { path = "../tracing-serde", optional = true }
 parking_lot = { version = ">= 0.7, < 0.10", features = ["owning_ref"], optional = true }
 
 [dev-dependencies]
-tracing = { path = "../tracing" }
+tracing = "0.1"
 log = "0.4"
-tracing-log = { path = "../tracing-log" }
+tracing-log = "0.1"
 criterion = { version = "0.3", default_features = false }
 
 [badges]

--- a/tracing-subscriber/src/fmt/format.rs
+++ b/tracing-subscriber/src/fmt/format.rs
@@ -321,6 +321,7 @@ where
         writer: &mut dyn fmt::Write,
         event: &Event<'_>,
     ) -> fmt::Result {
+        use tracing_serde::fields::AsMap;
         let mut timestamp = String::new();
         self.timer.format_time(&mut timestamp)?;
 
@@ -346,7 +347,7 @@ where
                 serializer.serialize_entry("target", meta.target())?;
             }
 
-            serializer.serialize_entry("fields", &event.values().as_serde())
+            serializer.serialize_entry("fields", &event.field_map())
         };
 
         visit().map_err(|_| fmt::Error)?;

--- a/tracing-tower/Cargo.toml
+++ b/tracing-tower/Cargo.toml
@@ -21,7 +21,7 @@ license = "MIT"
 default = ["tower-layer", "tower-util", "http"]
 
 [dependencies]
-tracing = { version = "0.1", path = "../tracing" }
+tracing = "0.1"
 tracing-futures = { version = "0.1.0", path = "../tracing-futures" }
 futures = "0.1"
 tower-service = "0.2"

--- a/tracing/Cargo.toml
+++ b/tracing/Cargo.toml
@@ -28,7 +28,7 @@ keywords = ["logging", "tracing", "metrics", "async"]
 edition = "2018"
 
 [dependencies]
-tracing-core = { path = "../tracing-core", default-features = false }
+tracing-core = { version = "0.1.6", default-features = false }
 log = { version = "0.4", optional = true }
 tracing-attributes = "0.1.3"
 cfg-if = "0.1.9"


### PR DESCRIPTION
Here's a proposal for an alternative way of formatting event fields as their own JSON object _without_ having to make changes in `tracing-core`, which I'd really prefer to avoid when not strictly necessary.

What do you think?